### PR TITLE
Make get_local_time use location parameter if it exists

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -169,7 +169,8 @@ class NetworkBase:
                 "\n\nOur time service requires a login/password to rate-limit. Please register for a free adafruit.io account and place the user/key in your secrets file under 'aio_username' and 'aio_key'"  # pylint: disable=line-too-long
             ) from KeyError
 
-        location = secrets.get("timezone", location)
+        if location is None:
+            location = secrets.get("timezone", location)
         if location:
             print("Getting time for timezone", location)
             api_url = (TIME_SERVICE + "&tz=%s") % (aio_username, aio_key, location)


### PR DESCRIPTION
redoing previous change from Nov16 in MatrixPortal lib.  

Change seemed to get lost during PortalBase work.