### PR TITLE
set_text_color: check if label is None before assigning value

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -307,7 +307,8 @@ class PortalBase:
         if self._text[index]:
             color = self.html_color_convert(color)
             self._text[index]["color"] = color
-            self._text[index]["label"].color = color
+            if self._text[index]["label"] is not None:
+                self._text[index]["label"].color = color
 
     def exit_and_deep_sleep(self, sleep_time):
         """


### PR DESCRIPTION
Make sure label of text is set before changing its color property.

Fixes: https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/issues/29