### PR TITLE
fix spi init

### DIFF
--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -63,7 +63,7 @@ class WiFi:
             esp32_gpio0 = DigitalInOut(board.ESP_GPIO0)
             esp32_reset = DigitalInOut(board.ESP_RESET)
             esp32_cs = DigitalInOut(board.ESP_CS)
-            spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+            spi = board.SPI()
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0


### PR DESCRIPTION
This seems to resolve [#113](https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/issues/113)

I think SCK pin was already initialized by something and this was trying to do it again with busio.SPI().

I tested this fix with the simpletest script from PyPortal repo examples dir.