### PR TITLE
moved spi block to where it's needed

### DIFF
--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -22,7 +22,6 @@ Implementation Notes
 
 import gc
 import board
-import busio
 from digitalio import DigitalInOut
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
@@ -63,7 +62,8 @@ class WiFi:
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection
-                spi = board.SPI() # without parameters is forgiving to being called twice
+                spi = board.SPI()
+                  
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0

--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -63,7 +63,7 @@ class WiFi:
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection
-                spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+                spi = busio.SPI()  # without parameters is forgiving to being called twice
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0

--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -54,16 +54,16 @@ class WiFi:
 
         if esp:  # If there was a passed ESP Object
             self.esp = esp
-            if external_spi:  # If SPI Object Passed
-                spi = external_spi
-            else:  # Else: Make ESP32 connection
-                spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
         else:
             esp32_ready = DigitalInOut(board.ESP_BUSY)
             esp32_gpio0 = DigitalInOut(board.ESP_GPIO0)
             esp32_reset = DigitalInOut(board.ESP_RESET)
             esp32_cs = DigitalInOut(board.ESP_CS)
-            spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
+            if external_spi:  # If SPI Object Passed
+                spi = external_spi
+            else:  # Else: Make ESP32 connection
+                spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0

--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -63,7 +63,7 @@ class WiFi:
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection
-                spi = busio.SPI()  # without parameters is forgiving to being called twice
+                spi = busio.SPI() # without parameters is forgiving to being called twice
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0

--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -63,7 +63,7 @@ class WiFi:
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection
-                spi = busio.SPI() # without parameters is forgiving to being called twice
+                spi = board.SPI() # without parameters is forgiving to being called twice
 
             self.esp = adafruit_esp32spi.ESP_SPIcontrol(
                 spi, esp32_cs, esp32_ready, esp32_reset, esp32_gpio0


### PR DESCRIPTION
without this block moved, there is an error regarding SCK in use


Traceback (most recent call last):
  File "code.py", line 80, in <module>
  File "/lib/adafruit_pyportal/__init__.py", line 152, in __init__
  File "/lib/adafruit_pyportal/network.py", line 95, in __init__
  File "adafruit_portalbase/wifi_coprocessor.py", line 66, in __init__
ValueError: SCK in use


The spi object is passed into the WiFi constructor, but if there was no esp object passed in, then the spi was ignored and attempted to be reconstructed.

Since spi isn't needed in the if esp block, I just moved it to the else block