### PR TITLE
Add MiniQR to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ adafruit-circuitpython-requests
 adafruit-circuitpython-adafruitio
 adafruit-circuitpython-simpleio
 adafruit-circuitpython-fakerequests
+adafruit-circuitpython-miniqr


### PR DESCRIPTION
It wasn't being included in the bundle. This should fix it.