### PR TITLE
Don't add "..." to every label of 3 or more characters

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -224,9 +224,9 @@ class PortalBase:
         if not self._text:
             self.add_text()
         string = str(val)
-        if self._text[index]["maxlen"]:
+        if self._text[index]["maxlen"] and len(string) > self._text[index]["maxlen"]:
+            # too long! shorten it
             if len(string) >= 3:
-                # too long! shorten it
                 string = string[: self._text[index]["maxlen"] - 3] + "..."
             else:
                 string = string[: self._text[index]["maxlen"]]


### PR DESCRIPTION
The actual length of the text was not tested in set_text, the mere existence of `maxlen` was enough to shorten the string, or add `"..."` if the string was shorter than `maxlen - 3`.