### PR TITLE
Added a maximum number of attempts for connecting to WiFi

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -348,7 +348,7 @@ class NetworkBase:
                 if max_attempts is not None and attempt >= max_attempts:
                     raise OSError(
                         "Maximum number of attempts reached when trying to connect to WiFi"
-                    )
+                    ) from error
                 print("Could not connect to internet", error)
                 print("Retrying in 3 seconds...")
                 attempt += 1

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -316,11 +316,12 @@ class NetworkBase:
         if not content_length == os.stat(filename)[6]:
             raise RuntimeError
 
-    def connect(self):
+    def connect(self, max_attempts=10):
         """
         Connect to WiFi using the settings found in secrets.py
         """
         self._wifi.neo_status(STATUS_CONNECTING)
+        attempt = 1
         while not self._wifi.is_connected:
             # secrets dictionary must contain 'ssid' and 'password' at a minimum
             print("Connecting to AP", self._secrets["ssid"])
@@ -340,8 +341,11 @@ class NetworkBase:
                 self._wifi.connect(self._secrets["ssid"], self._secrets["password"])
                 self.requests = self._wifi.requests
             except RuntimeError as error:
+                if max_attempts is not None and attempt >= max_attempts:
+                    raise OSError("Maximum attempts reached when trying to connect to WiFi")
                 print("Could not connect to internet", error)
                 print("Retrying in 3 seconds...")
+                attempt += 1
                 time.sleep(3)
             gc.collect()
 

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -319,6 +319,10 @@ class NetworkBase:
     def connect(self, max_attempts=10):
         """
         Connect to WiFi using the settings found in secrets.py
+
+        :param max_attempts: The maximum number of of attempts to connect to WiFi before
+                             failing or use None to disable. Defaults to 10.
+
         """
         self._wifi.neo_status(STATUS_CONNECTING)
         attempt = 1
@@ -342,7 +346,9 @@ class NetworkBase:
                 self.requests = self._wifi.requests
             except RuntimeError as error:
                 if max_attempts is not None and attempt >= max_attempts:
-                    raise OSError("Maximum attempts reached when trying to connect to WiFi")
+                    raise OSError(
+                        "Maximum number of attempts reached when trying to connect to WiFi"
+                    )
                 print("Could not connect to internet", error)
                 print("Retrying in 3 seconds...")
                 attempt += 1


### PR DESCRIPTION
Fixes #45. This sets the maximum attempts to 10 by default when connecting to WiFi. It can be overridden by passing an int or None to disable.