### PR TITLE
Update Connection Failure Exception to ConnectionError

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -343,7 +343,7 @@ class NetworkBase:
             try:
                 self._wifi.connect(self._secrets["ssid"], self._secrets["password"])
                 self.requests = self._wifi.requests
-            except RuntimeError as error:
+            except ConnectionError as error:
                 if max_attempts is not None and attempt >= max_attempts:
                     raise OSError(
                         "Maximum number of attempts reached when trying to connect to WiFi"


### PR DESCRIPTION
It looks like this may have been updated in CircuitPython 7, but this allows it to retry on connection failure up to 3 times.