### PR TITLE
add core modules to mock docs list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,8 @@ autodoc_mock_imports = [
     "secrets",
     "wifi",
     "socketpool",
+    "terminalio",
+    "displayio",
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
This is an attempt to get the docs generating correctly. It was noticed today on discord that the docs hosted here: https://docs.circuitpython.org/projects/portalbase/en/latest/ are essentially empty of the main content. They contain all of the boilerplate stuff, but not the actual documentation for this class.

I attempted the build locally and it failed initially because it couldn't find things from these core modules. Not sure how it could have passed in the CI container

After making the changes from this PR I am able to get successful builds of the docs pages and they do seem to include the documentation that is missing on the current live pages. 

![image](https://user-images.githubusercontent.com/2406189/159331040-c1fec005-e300-49f5-b66e-71f0bfa5840a.png)
