### PR TITLE
adding example directory and script

### DIFF
--- a/example/adafruit_portalbase_simpletest.py
+++ b/example/adafruit_portalbase_simpletest.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+NOTE: This PortalBase library is intended to be subclassed by other libraries rather than
+used directly by end users. This example shows one such usage with the PyPortal library.
+See MatrixPortal, MagTag, and PyPortal libraries for more examples.
+"""
+# NOTE: Make sure you've created your secrets.py file before running this example
+# https://learn.adafruit.com/adafruit-pyportal/internet-connect#whats-a-secrets-file-17-2
+
+
+import board
+from adafruit_pyportal import PyPortal
+
+# Set a data source URL
+TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
+
+# Create the PyPortal object
+pyportal = PyPortal(url=TEXT_URL, status_neopixel=board.NEOPIXEL)
+
+# Set display to show REPL
+board.DISPLAY.show(None)
+
+# Go get that data
+print("Fetching text from", TEXT_URL)
+data = pyportal.fetch()
+
+# Print out what we got
+print("-" * 40)
+print(data)
+print("-" * 40)


### PR DESCRIPTION
Another attempt to resolve the lack of content on the readthedocs page. 

I noticed that if you tack on `index.html` to the URL in RTD it does show a page and the page does have all relevant content on it: https://docs.circuitpython.org/projects/portalbase/en/latest/index.html

I looked through the raw logs from RTD https://readthedocs.org/projects/adafruit-circuitpython-portalbase/builds/16427060/ Nothing jumps out as immediately problematic to me. I tried to view this side-by-side with another build log from a different library to try to spot differences. The bulk of what I found does seem to make sense to me and I wouldn't think would be causing this issue, but I'm at a bit of a loss for ideas.

One difference I noticed was lack of examples directory. I know the examples do get listed in the docs page so I am working under the theory that maybe if this directory is missing it's causing some problem leading to the empty docs pages.

To test this I've added a PyPortal example into this repo. Ordinarily the user is not intended to use PortalBase directly but rather they would use the things that subclass from it. I think this is likely the reason that there were no examples originally. If this file existing allows the docs to get populated properly, then it may be worth having it here even though it's technically for the subclass rather than this directly.