### PR TITLE
Add adafruit_miniqr to setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "adafruit-circuitpython-adafruitio",
         "adafruit-circuitpython-simpleio",
         "adafruit-circuitpython-fakerequests",
+        "adafruit-circuitpython-miniqr",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
It isn't a top level import but there's no guard against failure to import, so I think it was intended to be a part of the `setup.py` `install_requires`.  If this is merged before https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/pull/85 it will still fail the CI, I think.