### PR TITLE
Use the correct object for PinAlarm and TouchAlarm

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -373,7 +373,7 @@ class PortalBase:
 
         """
         if self._alarm:
-            return self._alarm.time.PinAlarm(pin, value, edge, pull)
+            return self._alarm.pin.PinAlarm(pin, value, edge, pull)
         raise NotImplementedError(
             "Alarms not supported. Make sure you have the latest CircuitPython."
         )
@@ -385,7 +385,7 @@ class PortalBase:
         :param microcontroller.Pin pin: The trigger pin.
         """
         if self._alarm:
-            return self._alarm.time.TouchAlarm(pin)
+            return self._alarm.touch.TouchAlarm(pin)
         raise NotImplementedError(
             "Alarms not supported. Make sure you have the latest CircuitPython."
         )


### PR DESCRIPTION
Creating pin alarms using `create_pin_alarm` results in this:

```
Traceback (most recent call last):
  File "code.py", line 130, in <module>
  File "adafruit_portalbase/__init__.py", line 371, in create_pin_alarm
AttributeError: 'module' object has no attribute 'PinAlarm'
```

Looking into it, the code is using the wrong object to create both pin and touch alarms.