### PR TITLE
Add adafruit_esp32spi as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Adafruit-Blinka
 adafruit-blinka-displayio
 adafruit-circuitpython-bitmap-font
 adafruit-circuitpython-display-text
+adafruit-circuitpython-esp32spi
 adafruit-circuitpython-neopixel
 adafruit-circuitpython-requests
 adafruit-circuitpython-adafruitio

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "adafruit-blinka-displayio",
         "adafruit-circuitpython-bitmap-font",
         "adafruit-circuitpython-display-text",
+        "adafruit-circuitpython-esp32spi",
         "adafruit-circuitpython-neopixel",
         "adafruit-circuitpython-requests",
         "adafruit-circuitpython-adafruitio",


### PR DESCRIPTION
Adds the missing `adafruit_esp32spi` dependency, which is what is preventing #74 from passing CI as well.