### PR TITLE
Update docstrings to show wifi_esp32s2 should also work for esp32s3

### DIFF
--- a/adafruit_portalbase/wifi_esp32s2.py
+++ b/adafruit_portalbase/wifi_esp32s2.py
@@ -6,7 +6,7 @@
 `adafruit_portalbase.wifi_esp32s2`
 ================================================================================
 
-WiFi Helper module for the ESP32-S2 based boards.
+WiFi Helper module for the ESP32-S2 and ESP32-S3 based boards.
 
 
 * Author(s): Melissa LeBlanc-Williams
@@ -32,7 +32,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PortalBase.git"
 
 
 class WiFi:
-    """Class representing the WiFi portion of the ESP32-S2.
+    """Class representing the WiFi portion of the ESP32-S2/ESP32-S3.
 
     :param status_led: The initialized object for status DotStar, NeoPixel, or RGB LED. Defaults
                        to ``None``, to not use the status LED


### PR DESCRIPTION
Simple documentation change to show that even though it has esp32s2 in the name, it should work for the esp32-s3, which I have tested on an esp32-s3 tft in the past.