### PR TITLE
Fix missing bitmaptools issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = [
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = [
     "supervisor",
+    "bitmaptools",
     "rtc",
     "ssl",
     "secrets",


### PR DESCRIPTION
Apparently something changed (likely on a dependency) in the time period between when I submitted #93 and when it was merged in causing it to break. This should fix the issue.