### PR TITLE
Remove legacy requests.set_socket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 Adafruit-Blinka-displayio
 Adafruit-Blinka
 adafruit-circuitpython-bitmap-font
+adafruit-circuitpython-connectionmanager
 adafruit-circuitpython-display-text
 adafruit-circuitpython-neopixel
 adafruit-circuitpython-adafruitio


### PR DESCRIPTION
Remove legacy `requests.set_socket` and replace with new `pool` and `ssl_context` helpers from [ConnectionManager](https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager/)

This needs to be merged and released and in the bundle before we can merge https://github.com/adafruit/Adafruit_CircuitPython_Requests/pull/151