### PR TITLE
Add max_attempts to get_local_time

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -484,12 +484,12 @@ class PortalBase:
                 self._fetch_set_text(string, index=i)
                 value_index += 1
 
-    def get_local_time(self, location=None):
+    def get_local_time(self, location=None, max_attempts=10):
         """Accessor function for get_local_time()"""
         if self.network is None:
             raise RuntimeError("network must not be None to use get_local_time()")
 
-        return self.network.get_local_time(location=location)
+        return self.network.get_local_time(location=location, max_attempts=max_attempts)
 
     def push_to_io(self, feed_key, data, metadata=None, precision=None):
         """Push data to an adafruit.io feed

--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -55,7 +55,7 @@ class PortalBase:
 
     """
 
-    # pylint: disable=too-many-instance-attributes, too-many-branches, too-many-public-methods
+    # pylint: disable=too-many-instance-attributes, too-many-branches, too-many-public-methods, too-many-arguments
     def __init__(
         self,
         network,

--- a/adafruit_portalbase/graphics.py
+++ b/adafruit_portalbase/graphics.py
@@ -102,7 +102,7 @@ class GraphicsBase:
 
     def qrcode(
         self, qr_data, *, qr_size=1, x=0, y=0, qr_color=0x000000
-    ):  # pylint: disable=invalid-name
+    ):  # pylint: disable=invalid-name, too-many-arguments
         """Display a QR code
 
         :param qr_data: The data for the QR code, None to remove.

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -213,7 +213,7 @@ class NetworkBase:
 
         """
         # pylint: disable=line-too-long
-        self.connect()
+        self.connect(max_attempts=max_attempts)
         api_url = None
         reply = None
         try:
@@ -271,7 +271,7 @@ class NetworkBase:
                              failing or use None to disable. Defaults to 10.
 
         """
-        reply = self.get_strftime(TIME_SERVICE_FORMAT, location=location)
+        reply = self.get_strftime(TIME_SERVICE_FORMAT, location=location, max_attempts=max_attempts)
         if reply:
             times = reply.split(" ")
             the_date = times[0]

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -203,11 +203,13 @@ class NetworkBase:
         """
         return url.replace(" ", "+").replace("%", "%25").replace(":", "%3A")
 
-    def get_strftime(self, time_format, location=None):
+    def get_strftime(self, time_format, location=None, max_attempts=10):
         """
         Fetch a custom strftime relative to your location.
 
         :param str location: Your city and country, e.g. ``"America/New_York"``.
+        :param max_attempts: The maximum number of of attempts to connect to WiFi before
+                             failing or use None to disable. Defaults to 10.
 
         """
         # pylint: disable=line-too-long
@@ -259,12 +261,14 @@ class NetworkBase:
 
         return reply
 
-    def get_local_time(self, location=None):
+    def get_local_time(self, location=None, max_attempts=10):
         # pylint: disable=line-too-long
         """
         Fetch and "set" the local time of this microcontroller to the local time at the location, using an internet time API.
 
         :param str location: Your city and country, e.g. ``"America/New_York"``.
+        :param max_attempts: The maximum number of of attempts to connect to WiFi before
+                             failing or use None to disable. Defaults to 10.
 
         """
         reply = self.get_strftime(TIME_SERVICE_FORMAT, location=location)

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -271,7 +271,9 @@ class NetworkBase:
                              failing or use None to disable. Defaults to 10.
 
         """
-        reply = self.get_strftime(TIME_SERVICE_FORMAT, location=location, max_attempts=max_attempts)
+        reply = self.get_strftime(
+            TIME_SERVICE_FORMAT, location=location, max_attempts=max_attempts
+        )
         if reply:
             times = reply.split(" ")
             the_date = times[0]
@@ -635,7 +637,7 @@ class NetworkBase:
         json_path=None,
         regexp_path=None,
         timeout=10,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Fetch data from the specified url and perfom any parsing
 
         :param str url: The URL to fetch from.


### PR DESCRIPTION
get_local_time() calls get_strftime() which calls connect().
connect() defaults to max_attempts=10 to connect to the wifi. 
This patch allows the user to pass max_attempts to get_localtime() which will be passed to get_strftime() and used by connect(). 
Not setting the max_attempts value in get_local_time() uses the default max_attempts=10. 
Not setting the max_attempts value in get_strftime() uses the default max_attempts=10