### PR TITLE
Secrets cleanup

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -154,8 +154,7 @@ class NetworkBase:
         env_value = secrets.get(secrets_setting_name)
         if env_value is not None:
             warnings.warn(
-                "The using of `secrets`, is deprecated. Please put your settings in "
-                "settings.toml"
+                "Using secrets.py for network settings is deprecated. Put your settings in settings.toml."
             )
             self._settings[setting_name] = env_value
             return env_value
@@ -225,8 +224,8 @@ class NetworkBase:
             aio_key = self._get_setting("ADAFRUIT_AIO_KEY")
         except KeyError:
             raise KeyError(
-                "\n\nOur time service requires a login/password to rate-limit. "
-                "Please register for a free adafruit.io account and place the user/key in "
+                "\nThe Adafruit IO time service requires a login and password. "
+                "Rgister for a free adafruit.io account and put the username and key in "
                 "your settings.toml file under 'ADAFRUIT_AIO_USERNAME' and 'ADAFRUIT_AIO_KEY'"
             ) from KeyError
 
@@ -257,7 +256,7 @@ class NetworkBase:
             reply = response.text
         except KeyError:
             raise KeyError(
-                "Was unable to lookup the time, try setting 'timezone' in your settings.toml"
+                "Unable to lookup the time, try setting 'timezone' in your settings.toml"
                 "according to http://worldtimeapi.org/timezones"
             ) from KeyError
         # now clean up

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -154,7 +154,8 @@ class NetworkBase:
         env_value = secrets.get(secrets_setting_name)
         if env_value is not None:
             warnings.warn(
-                "Using secrets.py for network settings is deprecated. Put your settings in settings.toml."
+                "Using secrets.py for network settings is deprecated."
+                " Put your settings in settings.toml."
             )
             self._settings[setting_name] = env_value
             return env_value

--- a/adafruit_portalbase/wifi_coprocessor.py
+++ b/adafruit_portalbase/wifi_coprocessor.py
@@ -70,7 +70,6 @@ class WiFi:
 
         if self.esp.is_connected:
             self._set_requests()
-        self._manager = None
 
         gc.collect()
 
@@ -81,9 +80,9 @@ class WiFi:
 
     def connect(self, ssid, password):
         """
-        Connect to WiFi using the settings found in secrets.py
+        Connect to WiFi using the settings found in settings.toml
         """
-        self.esp.connect({"ssid": ssid, "password": password})
+        self.esp.connect(ssid, password)
         self._set_requests()
 
     def neo_status(self, value):
@@ -94,14 +93,6 @@ class WiFi:
         """
         if self.neopix:
             self.neopix.fill(value)
-
-    def manager(self, secrets):
-        """Initialize the WiFi Manager if it hasn't been cached and return it"""
-        if self._manager is None:
-            self._manager = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(
-                self.esp, secrets, None
-            )
-        return self._manager
 
     @property
     def is_connected(self):

--- a/examples/portalbase_simpletest.py
+++ b/examples/portalbase_simpletest.py
@@ -6,12 +6,12 @@ NOTE: This PortalBase library is intended to be subclassed by other libraries ra
 used directly by end users. This example shows one such usage with the PyPortal library.
 See MatrixPortal, MagTag, and PyPortal libraries for more examples.
 """
-# NOTE: Make sure you've created your secrets.py file before running this example
-# https://learn.adafruit.com/adafruit-pyportal/internet-connect#whats-a-secrets-file-17-2
+# NOTE: Make sure you've created your settings.toml file before running this example
+# https://learn.adafruit.com/adafruit-pyportal/create-your-settings-toml-file
 
 import board
-import displayio
 from adafruit_pyportal import PyPortal
+from displayio import CIRCUITPYTHON_TERMINAL
 
 # Set a data source URL
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
@@ -20,7 +20,7 @@ TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 pyportal = PyPortal(url=TEXT_URL, status_neopixel=board.NEOPIXEL)
 
 # Set display to show REPL
-board.DISPLAY.root_group = displayio.CIRCUITPYTHON_TERMINAL
+board.DISPLAY.root_group = CIRCUITPYTHON_TERMINAL
 
 # Go get that data
 print("Fetching text from", TEXT_URL)

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Alec Delaney, for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+
+pytest

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 Justin Myers
+#
+# SPDX-License-Identifier: Unlicense
+
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from adafruit_portalbase.network import NetworkBase
+
+
+@pytest.fixture
+def secrets():
+    sys.modules["secrets.secrets"] = {
+        "aio_key": "secret_aio_key",
+        "aio_username": "secret_aio_username",
+        "password": "secret_password",
+        "ssid": "secret_ssid",
+        "timezone": "secret_timezone",
+        "fallback_test": "secret_fallback_test",
+    }
+    yield
+    del sys.modules["secrets.secrets"]
+
+
+@pytest.fixture
+def settings_toml_current(monkeypatch):
+    monkeypatch.setenv("ADAFRUIT_AIO_KEY", "settings_current_aio_key")
+    monkeypatch.setenv("ADAFRUIT_AIO_USERNAME", "settings_current_aio_username")
+    monkeypatch.setenv("CIRCUITPY_WIFI_PASSWORD", "settings_current_password")
+    monkeypatch.setenv("CIRCUITPY_WIFI_SSID", "settings_current_ssid")
+    monkeypatch.setenv("timezone", "settings_current_timezone")
+
+
+@pytest.fixture
+def settings_toml_old(monkeypatch):
+    monkeypatch.setenv("AIO_KEY", "settings_old_aio_key")
+    monkeypatch.setenv("AIO_USERNAME", "settings_old_aio_username")
+    monkeypatch.setenv("CIRCUITPY_WIFI_PASSWORD", "settings_old_password")
+    monkeypatch.setenv("CIRCUITPY_WIFI_SSID", "settings_old_ssid")
+    monkeypatch.setenv("timezone", "settings_old_timezone")
+
+
+def test_get_setting_does_not_exist():
+    network = NetworkBase(None)
+    assert network._get_setting("test") == None
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("ADAFRUIT_AIO_KEY", "secret_aio_key"),
+        ("ADAFRUIT_AIO_USERNAME", "secret_aio_username"),
+        ("AIO_KEY", "secret_aio_key"),
+        ("AIO_USERNAME", "secret_aio_username"),
+        ("CIRCUITPY_WIFI_PASSWORD", "secret_password"),
+        ("CIRCUITPY_WIFI_SSID", "secret_ssid"),
+        ("timezone", "secret_timezone"),
+        ("not_found", None),
+    ),
+)
+def test_get_setting_in_secrets(secrets, key, value):
+    network = NetworkBase(None)
+    with mock.patch("adafruit_portalbase.network.warnings.warn") as mock_warnings:
+        assert network._get_setting(key) == value
+    if value:
+        mock_warnings.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("ADAFRUIT_AIO_KEY", "settings_current_aio_key"),
+        ("ADAFRUIT_AIO_USERNAME", "settings_current_aio_username"),
+        ("CIRCUITPY_WIFI_PASSWORD", "settings_current_password"),
+        ("CIRCUITPY_WIFI_SSID", "settings_current_ssid"),
+        ("timezone", "settings_current_timezone"),
+        ("not_found", None),
+    ),
+)
+def test_get_setting_in_settings_current(settings_toml_current, key, value):
+    network = NetworkBase(None)
+    with mock.patch("adafruit_portalbase.network.warnings.warn") as mock_warnings:
+        assert network._get_setting(key) == value
+    mock_warnings.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("ADAFRUIT_AIO_KEY", "settings_old_aio_key"),
+        ("ADAFRUIT_AIO_USERNAME", "settings_old_aio_username"),
+        ("CIRCUITPY_WIFI_PASSWORD", "settings_old_password"),
+        ("CIRCUITPY_WIFI_SSID", "settings_old_ssid"),
+        ("timezone", "settings_old_timezone"),
+        ("not_found", None),
+    ),
+)
+def test_get_setting_in_settings_old(settings_toml_old, key, value):
+    network = NetworkBase(None)
+    with mock.patch("adafruit_portalbase.network.warnings.warn") as mock_warnings:
+        assert network._get_setting(key) == value
+    mock_warnings.assert_not_called()
+    if key in ["ADAFRUIT_AIO_KEY", "ADAFRUIT_AIO_USERNAME"]:
+        assert os.getenv(key) is None
+
+
+def test_fallback(secrets, settings_toml_current):
+    network = NetworkBase(None)
+    with mock.patch("adafruit_portalbase.network.warnings.warn") as mock_warnings:
+        assert network._get_setting("ADAFRUIT_AIO_KEY") == "settings_current_aio_key"
+    mock_warnings.assert_not_called()
+    with mock.patch("adafruit_portalbase.network.warnings.warn") as mock_warnings:
+        assert network._get_setting("fallback_test") == "secret_fallback_test"
+    mock_warnings.assert_called()
+
+
+def test_value_stored(settings_toml_current):
+    network = NetworkBase(None)
+    with mock.patch("os.getenv", return_value="test") as mock_getenv:
+        assert network._get_setting("ADAFRUIT_AIO_KEY") == "test"
+    mock_getenv.assert_called()
+    with mock.patch("os.getenv", return_value="test") as mock_getenv:
+        assert network._get_setting("ADAFRUIT_AIO_KEY") == "test"
+    mock_getenv.assert_not_called()


### PR DESCRIPTION
Minor updates to remove secrets usage and update keys:
1. Remove `secrets_data`
2. Update `secrets.py` comments to `settings.toml`
3. Update AIO keys from `AIO_*` to `ADAFRUIT_AIO_*`
4. Update learn links to point to correct page for settings.toml
5. Update `adafruit_portalbase.network.NetworkBase._get_setting` to handle newer `ADAFRUIT_AIO_*` key names and show a warning when using secrets (tests added to make sure it's working as expected)

Tested on a PyPortal running 9.2.4