### PR TITLE
Change splash to root_group for more clarity

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -557,6 +557,10 @@ class PortalBase:
     @property
     def splash(self):
         """The root display group for this device (for backwards compatibility)."""
+        print(
+            "WARNING: splash is deprecated, use root_group instead. "
+            "This will be removed in a future release."
+        )
         return self.graphics.root_group
 
     @property

--- a/adafruit_portalbase/graphics.py
+++ b/adafruit_portalbase/graphics.py
@@ -168,4 +168,8 @@ class GraphicsBase:
     @property
     def splash(self):
         """The display's root group (for backwards compatibility)."""
+        print(
+            "WARNING: splash is deprecated, use root_group instead. "
+            "This will be removed in a future release."
+        )
         return self.display._root_group


### PR DESCRIPTION
To help avoid confusion and because "splash" was an antiquated reference to the splash screen, which really isn't relevant to the library. After this is merged, I'll go through the other libraries/examples and update those as well.