### PR TITLE
fix handling of single value text response

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -698,7 +698,7 @@ class NetworkBase:
             for regexp in regexp_path:
                 values.append(re.search(regexp, text).group(1))
         else:
-            values = text
+            values.append(text)
         return values
 
     def process_json(self, json_data, json_path):


### PR DESCRIPTION
setting `values = text` meant that a string was returned instead of a list. 

The code here: https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/blob/3dce5bca3bcd27354becc6d3ecf82244f1e26ffe/adafruit_portalbase/__init__.py#L458-L475

Seems to have been written assuming values will be a list. Since string in python behaves sort of like a list this results in it trying to put individual characters from the text into labels on the display. So if the user had only declared 1 text position this would put a label there with just the first letter of the response. 

The fix is to add text to the list of values that gets returned, that way a list containing text, `[text]`, is being returned instead of `text` itself. So the code inside the fill text labels function will then place the entire text response into a single label. 