### PR TITLE
Text fields property

### DIFF
--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -568,7 +568,6 @@ class PortalBase:
         """The displayio.Display object for this device."""
         return self.graphics.display
 
-
     @property
     def text_fields(self):
         return self._text

--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -567,3 +567,8 @@ class PortalBase:
     def display(self):
         """The displayio.Display object for this device."""
         return self.graphics.display
+
+
+    @property
+    def text_fields(self):
+        return self._text

--- a/adafruit_portalbase/__init__.py
+++ b/adafruit_portalbase/__init__.py
@@ -570,4 +570,8 @@ class PortalBase:
 
     @property
     def text_fields(self):
+        """
+        The list of text field(s) metadata objects.
+        See add_text() definition for available metadata fields.
+        """
         return self._text


### PR DESCRIPTION
Expose a `text_fields` property for the list of text field metadata objects `self._text`.

This allows external code to more easily access and manipulate the labels without having to remove and re-create them, or use the "private" field with leading underscore. I.e. move the text labels to different positions when certain buttons are pressed.