### PR TITLE
fix for access non-existing _root_group

### DIFF
--- a/adafruit_portalbase/graphics.py
+++ b/adafruit_portalbase/graphics.py
@@ -184,4 +184,4 @@ class GraphicsBase:
             "WARNING: splash is deprecated, use root_group instead. "
             "This will be removed in a future release."
         )
-        return self.display._root_group
+        return self.display.root_group


### PR DESCRIPTION
`Display` objects don't have a `_root_group` with leading underscore, only public `root_group`. This changes updates the reference to the latter. 