### PR TITLE
Validate wifi credentials

### DIFF
--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -385,6 +385,14 @@ class NetworkBase:
                     raise TypeError(
                         "'networks' must be a list/tuple of dicts of 'ssid' and 'password'"
                     )
+            
+            self._wifi_credentials = list(filter(
+                lambda credentials: isinstance(credentials, (list, tuple)) and "ssid" in credentials and "password" in credentials and type(credentials["ssid"]) is str and type(credentials["password"]) is str and len(credentials["ssid"]) and len(credentials["password"]),
+                self._wifi_credentials
+            ))
+            if not len(self._wifi_credentials):
+                self._wifi_credentials = None
+                raise OSError("No valid wifi credentials provided")
 
         for credentials in self._wifi_credentials:
             self._wifi.neo_status(STATUS_CONNECTING)

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -393,8 +393,7 @@ class NetworkBase:
                     and "password" in credentials
                     and isinstance(credentials["ssid"], str)
                     and isinstance(credentials["password"], str)
-                    and len(credentials["ssid"])
-                    and len(credentials["password"]),
+                    and len(credentials["ssid"]),
                     self._wifi_credentials,
                 )
             )

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -391,8 +391,8 @@ class NetworkBase:
                     lambda credentials: isinstance(credentials, (list, tuple))
                     and "ssid" in credentials
                     and "password" in credentials
-                    and type(credentials["ssid"]) is str
-                    and type(credentials["password"]) is str
+                    and isinstance(credentials["ssid"], str)
+                    and isinstance(credentials["password"], str)
                     and len(credentials["ssid"])
                     and len(credentials["password"]),
                     self._wifi_credentials,

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -400,7 +400,7 @@ class NetworkBase:
             )
             if not len(self._wifi_credentials):
                 self._wifi_credentials = None
-                raise OSError("No valid wifi credentials provided")
+                raise OSError("No wifi credentials provided")
 
         for credentials in self._wifi_credentials:
             self._wifi.neo_status(STATUS_CONNECTING)

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -388,7 +388,7 @@ class NetworkBase:
 
             self._wifi_credentials = list(
                 filter(
-                    lambda credentials: isinstance(credentials, (list, tuple))
+                    lambda credentials: isinstance(credentials, dict)
                     and "ssid" in credentials
                     and "password" in credentials
                     and isinstance(credentials["ssid"], str)

--- a/adafruit_portalbase/network.py
+++ b/adafruit_portalbase/network.py
@@ -385,11 +385,19 @@ class NetworkBase:
                     raise TypeError(
                         "'networks' must be a list/tuple of dicts of 'ssid' and 'password'"
                     )
-            
-            self._wifi_credentials = list(filter(
-                lambda credentials: isinstance(credentials, (list, tuple)) and "ssid" in credentials and "password" in credentials and type(credentials["ssid"]) is str and type(credentials["password"]) is str and len(credentials["ssid"]) and len(credentials["password"]),
-                self._wifi_credentials
-            ))
+
+            self._wifi_credentials = list(
+                filter(
+                    lambda credentials: isinstance(credentials, (list, tuple))
+                    and "ssid" in credentials
+                    and "password" in credentials
+                    and type(credentials["ssid"]) is str
+                    and type(credentials["password"]) is str
+                    and len(credentials["ssid"])
+                    and len(credentials["password"]),
+                    self._wifi_credentials,
+                )
+            )
             if not len(self._wifi_credentials):
                 self._wifi_credentials = None
                 raise OSError("No valid wifi credentials provided")

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -125,3 +125,19 @@ def test_value_stored(settings_toml_current):
     with mock.patch("os.getenv", return_value="test") as mock_getenv:
         assert network._get_setting("ADAFRUIT_AIO_KEY") == "test"
     mock_getenv.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("CIRCUITPY_WIFI_PASSWORD", ""),
+        ("CIRCUITPY_WIFI_SSID", ""),
+    ),
+)
+def test_invalid_wifi_credentials():
+    network = NetworkBase(None)
+    try:
+        network.connect()
+        assert False
+    except OSError as e:
+        assert True

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -127,14 +127,10 @@ def test_value_stored(settings_toml_current):
     mock_getenv.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("key", "value"),
-    (
-        ("CIRCUITPY_WIFI_PASSWORD", ""),
-        ("CIRCUITPY_WIFI_SSID", ""),
-    ),
-)
 def test_invalid_wifi_credentials():
+    for key in ("CIRCUITPY_WIFI_SSID", "CIRCUITPY_WIFI_PASSWORD"):
+        if os.getenv(key) is not None and os.getenv(key) != "":
+            assert False
     network = NetworkBase(None)
     try:
         network.connect()

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -139,5 +139,5 @@ def test_invalid_wifi_credentials():
     try:
         network.connect()
         assert False
-    except OSError as e:
+    except OSError:
         assert True


### PR DESCRIPTION
If a device hasn't been configured properly either with `CIRCUITPY_WIFI_SSID` and `CIRCUITPY_WIFI_PASSWORD` or the "networks" setting, `adafruit_portalbase.network.NetworkBase.connect` will result in an obscure `TypeError` from the `adafruit_esp32spi` library.

This update filters the `adafruit_portalbase.network.NetworkBase._wifi_credentials` list to ensure that it includes valid ssid/password pairs. If no valid credentials are available, it will trigger an `OSError` exception with a descriptive message.

I am testing using the following program written for the Adafruit Fruit Jam with the `adafruit_fruitjam` library. The device has no WiFi credentials configured.

``` python
from adafruit_fruitjam import FruitJam
fruitjam = FruitJam(url="https://www.adafruit.com")
fruitjam.fetch()
```

Here is the REPL output before this update:

```
Connecting to AP None
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "adafruit_fruitjam/__init__.py", line 302, in fetch
  File "adafruit_portalbase/network.py", line 552, in fetch
  File "adafruit_portalbase/network.py", line 406, in connect
  File "adafruit_portalbase/wifi_coprocessor.py", line 85, in connect
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 657, in connect
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 680, in connect_AP
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 548, in wifi_set_network
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 421, in _send_command_get_response
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 303, in _send_command
TypeError: object of type 'NoneType' has no len()
```

Here's the REPL output after this update:

```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "adafruit_fruitjam/__init__.py", line 302, in fetch
  File "/lib/adafruit_portalbase/network.py", line 560, in fetch
  File "/lib/adafruit_portalbase/network.py", line 395, in connect
OSError: No wifi credentials provided
```

_Note: I felt that `OSError` was appropriate for this exception because it is related to the device configuration before a request is made, but `ConnectionError` may follow the relative CPython implementation more closely._